### PR TITLE
Fix logic error in behavior list clipping

### DIFF
--- a/deepray/datasets/ali_display_ad_click/processing/prep_3_merge.py
+++ b/deepray/datasets/ali_display_ad_click/processing/prep_3_merge.py
@@ -54,11 +54,11 @@ def _clip_clicks(row, behavior_log_cols, duration):
     ts_list = row[ts_col]
     begin_idx = 0
     end_idx = len(ts_list)
-    for ts in ts_list:
+    for i, ts in enumerate(ts_list):
       if ts < min_ts:
-        begin_idx += 1
+        begin_idx = max(begin_idx, i + 1)
       elif ts >= max_ts:
-        end_idx -= 1
+        end_idx = min(end_idx, i)
     for col in cols:
       row[col] = row[col][begin_idx:end_idx]
   return row


### PR DESCRIPTION
The previous implementation of `_clip_clicks` used simple increments/decrements on `begin_idx` and `end_idx` based on timestamp conditions. This was problematic because:
1. If multiple timestamps satisfied the condition, indices could cross or become invalid.
2. It didn't correctly identify the boundaries of the valid history window within the list.

The fix updates `begin_idx` to be the index after the last timestamp that is too old, and `end_idx` to be the index of the first timestamp that is too new (or equal to max_ts), ensuring a correct slice for the behavior lists.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.